### PR TITLE
Country name shouldn't be lowercased by default

### DIFF
--- a/app/CountryCodePicker/src/main/java/com/utkuglsvn/countrycodepicker/libData/CountryCode.kt
+++ b/app/CountryCodePicker/src/main/java/com/utkuglsvn/countrycodepicker/libData/CountryCode.kt
@@ -9,5 +9,5 @@ data class CountryCode(
     val flagResID: Int = 0
 ) {
     val countryCode = cCode.lowercase(Locale.getDefault())
-    val countryName = cName.lowercase(Locale.getDefault())
+    val countryName = cName
 }


### PR DESCRIPTION
- Maintaining the correct capitalization of the country's name is essential